### PR TITLE
Disable dependabot for maven

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,9 @@ updates:
       prefix: ".github:"
 
   # Maintain dependencies for Go
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "maven:"
+#  - package-ecosystem: "maven"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    commit-message:
+#      prefix: "maven:"


### PR DESCRIPTION
I propose disabling dependabot in this repo for Java dependencies, as we don't have a test suite that would allow us to be reasonably sure updates won't break the code.

Alternatively, we could just disable the auto-merge action, but I'm not sure we will put in the effort to manually test updates as they come in.